### PR TITLE
allow ntfy-to-slack to be configured at runtime instead of compile-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Rudimentary Go daemon to subscribe to a Ntfy topic and send the messages to a Sl
 ## Instructions (Linux/macOS/Windows docker)
 
 1. ```git clone https://github.com/ozskywalker/ntfy-to-slack```
-2. Edit ntfy-to-slack.go, replacing Topic & Webhook URL constants with appropriate URLs
-3. ```docker build -t ozskywalker/ntfy-to-slack```
-4. ```docker run -d --restart always ozskywalker/ntfy-to-slack:latest```
+2. ```docker build -t ozskywalker/ntfy-to-slack```
+3. ```
+   docker run --env="NTFY_DOMAIN=<my-ntfy-server>" --env="NTFY_TOPIC=<my-ntfy-topic>" --env="SLACK_WEBHOOK_URL=<my-slack-webhook>" -d --restart always ozskywalker/ntfy-to-slack:latest
+   ```
 
 ## Instructions (regular binary)
 
 1. ```git clone https://github.com/ozskywalker/ntfy-to-slack```
-2. Edit ntfy-to-slack.go, replacing Topic & Webhook URL constants with appropriate URLs
-3. ```go build .```
+2. ```go build .```
 
-Run the resulting binary at your own lesiure.
+Run the resulting binary at your own leisure, with either environment variables or flags to specify configuration.


### PR DESCRIPTION
This contribution allows ntfy-to-slack to be configured at runtime, instead of compile-time by providing either environment variables or commandline flags.

Doing this allows users to not have to worry about compiling the binary but rather just what configuration they would like to use.