### PR TITLE
fix: include failure detail in post-processing and delivery errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,5 +80,9 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          # Pinned rather than "latest": a new golangci-lint release can add or
+          # retune linters and turn CI red on an unrelated commit. Bump this
+          # deliberately, and keep it in step with GOLANGCI_LINT_VERSION in the
+          # Makefile so local runs match.
+          version: v2.12.2
           args: --disable=errcheck --enable=govet,ineffassign,staticcheck --timeout=5m

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,14 +72,32 @@ go test -v ./tests/...
 **IMPORTANT:** Always run linting locally before committing to match CI behavior:
 
 ```bash
-# Run the same linting configuration as CI
-golangci-lint run --disable=errcheck --enable=govet,ineffassign,staticcheck --timeout=5m
+# Run the same golangci-lint version and flags as CI
+make lint-golangci
 
 # Alternative: Run with default linters (more strict)
 golangci-lint run --timeout=5m
 ```
 
-The CI pipeline uses a specific linter configuration. Make sure to test locally with the exact same flags to avoid CI failures.
+`make lint-golangci` is the source of truth for the flags and warns if the
+installed golangci-lint differs from the version CI pins. The pinned version
+lives in two places that must stay in step: `GOLANGCI_LINT_VERSION` in the
+`Makefile` and `version:` in `.github/workflows/test.yml`.
+
+### Installing golangci-lint
+
+Download the official release binary for the pinned version. **Do not use
+`go install`:** it builds golangci-lint with the Go toolchain named in
+golangci-lint's own `go.mod`, which is older than the one this module targets,
+and the resulting binary refuses to lint it with:
+
+```
+can't load config: the Go language version (go1.25) used to build golangci-lint
+is lower than the targeted Go version (1.26.6)
+```
+
+The official release binaries are built with a newer Go and do not have this
+problem. `golangci-lint-action` in CI downloads those same release binaries.
 
 ## Build and Version Commands
 
@@ -98,7 +116,7 @@ goreleaser build --single-target --snapshot --clean
 
 Before committing changes:
 1. **Run tests**: `go test -v ./tests/...`
-2. **Run linting**: `golangci-lint run --disable=errcheck --enable=govet,ineffassign,staticcheck --timeout=5m`
+2. **Run linting**: `make lint-golangci`
 3. **Build application**: `go build -v ./cmd/ntfy-to-slack`
 4. **Test version system**: `./ntfy-to-slack -v`
 5. **Check formatting**: `go fmt ./...`

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-unit test-integration test-coverage build clean help fmt fmt-check lint
+.PHONY: test test-unit test-integration test-coverage build clean help fmt fmt-check lint lint-golangci
 
 # Go parameters
 GOCMD=go
@@ -8,6 +8,10 @@ GOTEST=$(GOCMD) test
 GOGET=$(GOCMD) get
 GOMOD=$(GOCMD) mod
 BINARY_NAME=ntfy-to-slack
+
+# Keep in step with .github/workflows/test.yml so local runs match CI.
+GOLANGCI_LINT_VERSION=v2.12.2
+GOLANGCI_LINT_ARGS=--disable=errcheck --enable=govet,ineffassign,staticcheck --timeout=5m
 
 help: ## Show this help message
 	@echo 'Usage:'
@@ -61,5 +65,21 @@ fmt-check: ## Check if code is properly formatted
 
 lint: fmt-check ## Run formatting check and go vet
 	$(GOCMD) vet ./cmd/... ./internal/... ./tests/...
+
+lint-golangci: ## Run golangci-lint with the same version and flags as CI
+	@command -v golangci-lint >/dev/null 2>&1 || { \
+		echo "golangci-lint not found. Install the official $(GOLANGCI_LINT_VERSION) release binary:"; \
+		echo "  https://github.com/golangci/golangci-lint/releases/tag/$(GOLANGCI_LINT_VERSION)"; \
+		echo ""; \
+		echo "Do not use 'go install': it builds golangci-lint with the Go toolchain"; \
+		echo "named in golangci-lint's own go.mod, which is older than the one this"; \
+		echo "module targets, and the resulting binary refuses to lint it."; \
+		exit 1; \
+	}
+	@installed=$$(golangci-lint version --short 2>/dev/null || echo unknown); \
+	if [ "v$$installed" != "$(GOLANGCI_LINT_VERSION)" ]; then \
+		echo "warning: golangci-lint v$$installed installed, CI uses $(GOLANGCI_LINT_VERSION)"; \
+	fi
+	golangci-lint run $(GOLANGCI_LINT_ARGS)
 
 all: clean deps lint test build ## Run full build pipeline

--- a/internal/config/postprocessor.go
+++ b/internal/config/postprocessor.go
@@ -199,7 +199,7 @@ func (w *WebhookPostProcessor) Process(message *NtfyMessage) (*SlackMessage, err
 			// Don't retry on client errors (4xx), only on server errors (5xx) and network issues
 			if resp.StatusCode >= 400 && resp.StatusCode < 500 {
 				slog.Debug("webhook client error, not retrying", "status", resp.StatusCode)
-				return nil, lastErr
+				return nil, fmt.Errorf("webhook post-processing failed (%s): %w", w.webhookURL, lastErr)
 			}
 
 			slog.Debug("webhook server error, will retry", "status", resp.StatusCode, "attempt", attempt+1)
@@ -236,5 +236,6 @@ func (w *WebhookPostProcessor) Process(message *NtfyMessage) (*SlackMessage, err
 		return &slackMsg, nil
 	}
 
-	return nil, fmt.Errorf("webhook failed after %d retries: %w", w.maxRetries+1, lastErr)
+	// maxRetries+1 is the number of attempts made, not the number of retries.
+	return nil, fmt.Errorf("webhook post-processing failed after %d attempts (%s): %w", w.maxRetries+1, w.webhookURL, lastErr)
 }

--- a/internal/ntfy/ntfy.go
+++ b/internal/ntfy/ntfy.go
@@ -6,9 +6,14 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/ozskywalker/ntfy-to-slack/internal/config"
 )
+
+// maxErrorBodyBytes caps how much of a failed ntfy response is read for the
+// error detail.
+const maxErrorBodyBytes = 1024
 
 // Client interface for ntfy operations
 type Client interface {
@@ -73,11 +78,19 @@ func (n *HTTPClient) Connect() (io.ReadCloser, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		// ntfy describes the failure in the body (e.g. {"code":40101,
+		// "error":"unauthorized"}), which is far more actionable than the
+		// status code alone.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
 		if closeErr := resp.Body.Close(); closeErr != nil {
 			slog.Debug("failed to close response body", "err", closeErr)
 		}
-		slog.Error("invalid status code", "expected", http.StatusOK, "domain", n.domain, "statusCode", resp.StatusCode)
-		return nil, fmt.Errorf("invalid response code from ntfy: %d", resp.StatusCode)
+		detail := strings.TrimSpace(string(body))
+		if detail == "" {
+			detail = "(empty response body)"
+		}
+		slog.Error("invalid status code", "expected", http.StatusOK, "domain", n.domain, "statusCode", resp.StatusCode, "body", detail)
+		return nil, fmt.Errorf("invalid response code from ntfy: %d: %s", resp.StatusCode, detail)
 	}
 
 	return resp.Body, nil

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"bufio"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 
@@ -42,7 +43,7 @@ func (p *MessageProcessor) ProcessStream(reader io.Reader) error {
 		}
 
 		if err := p.processMessage(&msg); err != nil {
-			slog.Error("error processing message", "err", err)
+			slog.Error("error processing message", "err", err, "msg_id", msg.Id, "topic", msg.Topic)
 		}
 	}
 
@@ -68,22 +69,30 @@ func (p *MessageProcessor) processMessage(msg *config.NtfyMessage) error {
 
 // handleMessageEvent handles ntfy message events
 func (p *MessageProcessor) handleMessageEvent(msg *config.NtfyMessage) error {
-	slog.Info("received message from ntfy", "title", msg.Title, "message", msg.Message)
+	// Scope every line for this message to the id ntfy assigned it, so a
+	// failure can be correlated back to the message that produced it.
+	log := slog.With("msg_id", msg.Id, "topic", msg.Topic)
+	log.Info("received message from ntfy", "title", msg.Title, "message", msg.Message)
 
 	// Use post-processor if available
 	if p.postProcessor != nil {
-		slog.Info("sending message to post-processor")
+		log.Info("sending message to post-processor")
 		slackMsg, err := p.postProcessor.Process(msg)
 		if err != nil {
-			slog.Warn("post-processing failed, using default format", "err", err, "title", msg.Title)
-			return p.sender.Send(p.createDefaultMessage(msg))
+			log.Warn("post-processing failed, using default format", "err", err, "title", msg.Title)
+			if sendErr := p.sender.Send(p.createDefaultMessage(msg)); sendErr != nil {
+				// Name the fallback explicitly: what reached Slack was the
+				// default format, not the post-processed message.
+				return fmt.Errorf("delivering default-format fallback: %w", sendErr)
+			}
+			return nil
 		}
-		slog.Info("post-processing complete, sending to Slack")
-		slog.Debug("post-processed message", "text", slackMsg.Text)
+		log.Info("post-processing complete, sending to Slack")
+		log.Debug("post-processed message", "text", slackMsg.Text)
 		return p.sender.Send(slackMsg)
 	}
 
-	slog.Info("sending message to Slack", "title", msg.Title)
+	log.Info("sending message to Slack", "title", msg.Title)
 	return p.sender.Send(p.createDefaultMessage(msg))
 }
 

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -4,14 +4,20 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
-	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ozskywalker/ntfy-to-slack/internal/config"
 )
+
+// maxResponseBytes caps how much of the Slack response is read. Slack's
+// replies are short status strings ("ok", "invalid_payload"), so this is
+// generous while keeping a misbehaving endpoint from exhausting memory.
+const maxResponseBytes = 1024
 
 // Sender implements MessageSender interface
 type Sender struct {
@@ -72,15 +78,22 @@ func (s *Sender) Send(message *config.SlackMessage) error {
 		}
 	}(resp.Body)
 
-	if body, err := io.ReadAll(resp.Body); err != nil {
-		slog.Error("error parsing body", "err", err)
-		return err
-	} else {
-		slog.Debug("slack response", "status", resp.StatusCode, "body", string(body))
+	// Slack explains rejections in the response body (invalid_payload, no_text,
+	// channel_not_found, ...), so keep it in scope for the error below instead
+	// of discarding it after a debug log. The webhook URL is a credential and
+	// must never appear in the returned error.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return fmt.Errorf("reading Slack response (status %d): %w", resp.StatusCode, err)
 	}
+	slog.Debug("slack response", "status", resp.StatusCode, "body", string(body))
 
 	if resp.StatusCode >= 400 {
-		return errors.New("error status code " + strconv.FormatInt(int64(resp.StatusCode), 10))
+		detail := strings.TrimSpace(string(body))
+		if detail == "" {
+			detail = "(empty response body)"
+		}
+		return fmt.Errorf("slack webhook returned %d: %s", resp.StatusCode, detail)
 	}
 
 	return nil

--- a/tests/unit/error_messaging_test.go
+++ b/tests/unit/error_messaging_test.go
@@ -1,0 +1,313 @@
+package unit_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ozskywalker/ntfy-to-slack/internal/config"
+	"github.com/ozskywalker/ntfy-to-slack/internal/ntfy"
+	"github.com/ozskywalker/ntfy-to-slack/internal/processor"
+	"github.com/ozskywalker/ntfy-to-slack/internal/slack"
+)
+
+// These tests pin the operator-facing error text described in issue #16, where
+// a Slack rejection surfaced only as "error status code 400" with no
+// indication of which pipeline stage failed, which message it belonged to, or
+// why Slack rejected it.
+
+// recordedLog is a captured log record with its attributes flattened.
+type recordedLog struct {
+	message string
+	attrs   map[string]string
+}
+
+// recorder collects records from a handler and every handler derived from it
+// via WithAttrs, so attributes attached by slog.With are visible to assertions.
+type recorder struct {
+	records []recordedLog
+}
+
+type recordingHandler struct {
+	rec  *recorder
+	base []slog.Attr
+}
+
+func (h *recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	entry := recordedLog{message: r.Message, attrs: map[string]string{}}
+	for _, a := range h.base {
+		entry.attrs[a.Key] = a.Value.String()
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		entry.attrs[a.Key] = a.Value.String()
+		return true
+	})
+	h.rec.records = append(h.rec.records, entry)
+	return nil
+}
+
+func (h *recordingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &recordingHandler{rec: h.rec, base: append(append([]slog.Attr{}, h.base...), attrs...)}
+}
+
+func (h *recordingHandler) WithGroup(string) slog.Handler { return h }
+
+// captureRecords installs an attribute-capturing handler as the default logger
+// and restores the original logger afterwards.
+func captureRecords(t *testing.T) *recorder {
+	t.Helper()
+	rec := &recorder{}
+	original := slog.Default()
+	slog.SetDefault(slog.New(&recordingHandler{rec: rec}))
+	t.Cleanup(func() { slog.SetDefault(original) })
+	return rec
+}
+
+func (r *recorder) find(message string) (recordedLog, bool) {
+	for _, entry := range r.records {
+		if entry.message == message {
+			return entry, true
+		}
+	}
+	return recordedLog{}, false
+}
+
+// failingBody is a ReadCloser that always fails to read.
+type failingBody struct{}
+
+func (failingBody) Read([]byte) (int, error) { return 0, errors.New("connection reset") }
+func (failingBody) Close() error             { return nil }
+
+func TestSlackSender_ErrorIncludesResponseBody(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantParts  []string
+	}{
+		{
+			name:       "400 invalid_payload",
+			statusCode: http.StatusBadRequest,
+			body:       "invalid_payload",
+			wantParts:  []string{"slack webhook returned 400", "invalid_payload"},
+		},
+		{
+			name:       "403 invalid_token",
+			statusCode: http.StatusForbidden,
+			body:       "invalid_token",
+			wantParts:  []string{"slack webhook returned 403", "invalid_token"},
+		},
+		{
+			name:       "500 with empty body",
+			statusCode: http.StatusInternalServerError,
+			body:       "",
+			wantParts:  []string{"slack webhook returned 500", "(empty response body)"},
+		},
+		{
+			name:       "body is trimmed",
+			statusCode: http.StatusBadRequest,
+			body:       "  no_text\n",
+			wantParts:  []string{"slack webhook returned 400: no_text"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			err := slack.NewSender(server.URL, nil).Send(&config.SlackMessage{Text: "hello"})
+			if err == nil {
+				t.Fatal("expected an error for a >=400 response")
+			}
+			for _, want := range tt.wantParts {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q missing %q", err.Error(), want)
+				}
+			}
+		})
+	}
+}
+
+// The Slack webhook URL is a bearer credential and must never be echoed into
+// an error that lands in logs.
+func TestSlackSender_ErrorDoesNotLeakWebhookURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("invalid_payload"))
+	}))
+	defer server.Close()
+
+	const secret = "XXXXXXXXXXXXXXXXXXXXXXXX"
+	err := slack.NewSender(server.URL+"/services/T00000000/B00000000/"+secret, nil).
+		Send(&config.SlackMessage{Text: "hello"})
+	if err == nil {
+		t.Fatal("expected an error for a 400 response")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Errorf("error leaks the Slack webhook URL: %q", err.Error())
+	}
+}
+
+// A response whose body cannot be read should still report the status it was
+// reading, rather than a bare I/O error.
+func TestSlackSender_ReadErrorReportsStatus(t *testing.T) {
+	client := &MockHTTPClient{
+		DoFunc: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       failingBody{},
+				Header:     make(http.Header),
+			}, nil
+		},
+	}
+
+	err := slack.NewSender("https://hooks.slack.com/services/test", client).
+		Send(&config.SlackMessage{Text: "hello"})
+	if err == nil {
+		t.Fatal("expected an error when the response body cannot be read")
+	}
+	if !strings.Contains(err.Error(), "status 200") {
+		t.Errorf("error %q should name the status it was reading", err.Error())
+	}
+}
+
+// Every per-message log line, and the terminal error, must carry the ntfy
+// message id so a failure can be traced back to the message that caused it.
+func TestMessageProcessor_LogsCarryMessageID(t *testing.T) {
+	rec := captureRecords(t)
+
+	p := processor.New(&MockMessageSender{SendError: errors.New("slack webhook returned 400: invalid_payload")})
+
+	input := `{"id":"Bx9kL2mQ","event":"message","topic":"alerts","title":"","message":"blah test"}`
+	if err := p.ProcessStream(strings.NewReader(input)); err != nil {
+		t.Fatalf("ProcessStream error: %v", err)
+	}
+
+	for _, message := range []string{
+		"received message from ntfy",
+		"sending message to Slack",
+		"error processing message",
+	} {
+		entry, ok := rec.find(message)
+		if !ok {
+			t.Fatalf("expected log record %q, captured %v", message, rec.records)
+		}
+		if entry.attrs["msg_id"] != "Bx9kL2mQ" {
+			t.Errorf("record %q: msg_id = %q, want %q", message, entry.attrs["msg_id"], "Bx9kL2mQ")
+		}
+		if entry.attrs["topic"] != "alerts" {
+			t.Errorf("record %q: topic = %q, want %q", message, entry.attrs["topic"], "alerts")
+		}
+	}
+}
+
+// When post-processing fails the message is still delivered, but in the default
+// format. If that delivery also fails, the error must say which one it was.
+func TestMessageProcessor_FallbackDeliveryErrorIsNamed(t *testing.T) {
+	rec := captureRecords(t)
+
+	post := &MockPostProcessor{
+		ProcessFunc: func(*config.NtfyMessage) (*config.SlackMessage, error) {
+			return nil, errors.New("webhook returned status 502: upstream down")
+		},
+	}
+	p := processor.NewWithPostProcessor(
+		&MockMessageSender{SendError: errors.New("slack webhook returned 400: invalid_payload")},
+		post,
+	)
+
+	input := `{"id":"Bx9kL2mQ","event":"message","topic":"alerts","message":"blah test"}`
+	if err := p.ProcessStream(strings.NewReader(input)); err != nil {
+		t.Fatalf("ProcessStream error: %v", err)
+	}
+
+	entry, ok := rec.find("error processing message")
+	if !ok {
+		t.Fatalf("expected an error record for the failed fallback delivery, captured %v", rec.records)
+	}
+	if !strings.Contains(entry.attrs["err"], "delivering default-format fallback") {
+		t.Errorf("err = %q, want it to name the default-format fallback", entry.attrs["err"])
+	}
+	if !strings.Contains(entry.attrs["err"], "invalid_payload") {
+		t.Errorf("err = %q, want it to preserve the underlying Slack reason", entry.attrs["err"])
+	}
+}
+
+func TestWebhookPostProcessor_ErrorNamesTargetAndAttempts(t *testing.T) {
+	t.Run("client error names the target", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"error":"template var 'severity' missing"}`))
+		}))
+		defer server.Close()
+
+		_, err := config.NewWebhookPostProcessorWithConfig(server.URL, 5, 0, 1).
+			Process(&config.NtfyMessage{Message: "hi"})
+		if err == nil {
+			t.Fatal("expected an error for a 422 response")
+		}
+		for _, want := range []string{"webhook post-processing failed", server.URL, "status 422", "severity"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q missing %q", err.Error(), want)
+			}
+		}
+	})
+
+	t.Run("exhausted retries report attempts, not retries", func(t *testing.T) {
+		var calls int
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			calls++
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte("upstream down"))
+		}))
+		defer server.Close()
+
+		// maxRetries=1 means 2 attempts: the original plus one retry.
+		_, err := config.NewWebhookPostProcessorWithConfig(server.URL, 5, 1, 1).
+			Process(&config.NtfyMessage{Message: "hi"})
+		if err == nil {
+			t.Fatal("expected an error after retries are exhausted")
+		}
+		if calls != 2 {
+			t.Errorf("server saw %d calls, want 2", calls)
+		}
+		for _, want := range []string{"failed after 2 attempts", server.URL, "status 502", "upstream down"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q missing %q", err.Error(), want)
+			}
+		}
+	})
+}
+
+func TestNtfyClient_ConnectErrorIncludesResponseBody(t *testing.T) {
+	client := &MockHTTPClient{
+		DoFunc: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Body:       io.NopCloser(strings.NewReader(`{"code":40101,"error":"unauthorized"}`)),
+				Header:     make(http.Header),
+			}, nil
+		},
+	}
+
+	_, err := ntfy.NewClient("ntfy.sh", "test-topic", "", client).Connect()
+	if err == nil {
+		t.Fatal("expected an error for a 401 response")
+	}
+	for _, want := range []string{"invalid response code from ntfy: 401", "unauthorized"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #16

## The finding

The error reported in #16 wasn't from post-processing at all.

`error status code 400` had exactly one source — `internal/slack/slack.go:83`. It was the *Slack delivery* failing; post-processing had succeeded. Reproduced by running the real pipeline against a fake Slack returning `400 invalid_payload`:

```
INFO  received message from ntfy title="" message="blah test"
INFO  sending message to post-processor
INFO  post-processing complete, sending to Slack     ← post-processing was fine
ERROR error processing message err="error status code 400"
```

Two defects sat behind the report:

1. **Misattribution.** `processor.go:45` logged `"error processing message"` for *every* per-message failure — post-processing and Slack delivery alike, so a 400 there sent you looking in the wrong place.
2. **The diagnostic was read, then discarded.** `slack.go:78` already called `io.ReadAll(resp.Body)` and logged it at **Debug** only. Slack's body is exactly what's needed (`invalid_payload`, `no_text`, `channel_not_found`, `invalid_token`), and it was dropped at the moment the error was constructed — so reproducing meant restarting the daemon at `LOG_LEVEL=debug` and waiting for the fault to recur.

## Changes

Two commits.

### `fix:` — error and log detail

| File | Change |
|---|---|
| `internal/slack/slack.go` | Keep the response body in scope and report it: `slack webhook returned 400: invalid_payload`. Names its own stage, so nothing upstream needs to wrap it. The webhook URL is a bearer credential and is deliberately excluded. |
| `internal/processor/processor.go` | `slog.With("msg_id", msg.Id, "topic", msg.Topic)` scopes every per-message line; the terminal error carries both. `NtfyMessage.Id` was previously referenced nowhere in the codebase. |
| `internal/processor/processor.go` | When post-processing fails the message still ships in default format; if *that* delivery then fails the error says `delivering default-format fallback: …`, so it's clear which payload reached Slack. |
| `internal/config/postprocessor.go` | Name the target webhook, and report attempts rather than retries — the old wording was off by one (`maxRetries=1` printed "after 2 retries" for 2 attempts). |
| `internal/ntfy/ntfy.go` | Same pattern on connect: include ntfy's own error body (`{"code":40101,"error":"unauthorized"}`) instead of a bare status code. |

Same failure as reported, after the change:

```
INFO  received message from ntfy msg_id=Bx9kL2mQ topic=alerts title="" message="blah test"
INFO  sending message to post-processor msg_id=Bx9kL2mQ topic=alerts
INFO  post-processing complete, sending to Slack msg_id=Bx9kL2mQ topic=alerts
ERROR error processing message err="slack webhook returned 400: invalid_payload" msg_id=Bx9kL2mQ topic=alerts
```

**Deliberately not done:** a `stage`/`Kind()` field on the `PostProcessor` interface, a `stageError` wrapper type, per-message request IDs, metrics. Once each error names its own stage in its text, the extra machinery buys nothing here. No new types, no interface changes, no new dependencies.

### `build:` — pin golangci-lint

CI requested golangci-lint `latest`, which floats — a new release can add or retune linters and turn CI red on a commit that changed nothing relevant. Pinned to the version CI already resolves to (`v2.12.2`), and added `make lint-golangci` so local runs use the same version and flags, warning when the installed binary differs.

Also documented a trap worth knowing: `go install` builds golangci-lint with the Go toolchain named in *its* `go.mod` (1.25.x), and such a binary refuses to lint a module targeting 1.26.6. The official release binaries — which `golangci-lint-action` downloads — are built with a newer Go and work fine.

## Testing

New `tests/unit/error_messaging_test.go` pins the operator-facing error text so it doesn't regress: the four error strings, a guard asserting the Slack webhook URL never leaks into an error, and the attempts-vs-retries count. No test previously asserted on any error string — `processor_logging_test.go` captures `r.Message` only.

Verified locally against the full `CLAUDE.md` checklist: `go test ./tests/...` green (unit + integration), `go vet` clean, `gofmt` clean, `make lint-golangci` reports 0 issues, `go build` + `-v` fine.

## Note

`app.go:41` logs the post-process webhook URL in full at INFO. If anyone puts a token in that URL it's already in their logs. Unrelated to this change and left alone — flagging it as a possible separate issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdfUkfeVW263UEwCVQrU5w)_