### PR TITLE
build: pass coverage report to codecov via files input

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:
-          file: ./coverage.out
+          files: ./coverage.out
 
   lint:
     name: Lint


### PR DESCRIPTION
codecov-action renamed the input from file to files; v7 rejects the old name outright, warning "Unexpected input(s) 'file'" and leaving CC_FILES empty. Uploads have kept working only because the CLI's workspace search happens to find coverage.out at the repo root -- an accident that breaks as soon as a second coverage file exists or the file moves.

Claude-Session: https://claude.ai/code/session_011HfA4VDyuYyEvZr2TPvsYT