### PR TITLE
build: migrate goreleaser config to v2 and pin action to v2 line

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: latest
+          version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,4 @@
-version: 1
+version: 2
 
 before:
   hooks:
@@ -27,10 +27,10 @@ builds:
     main: ./cmd/ntfy-to-slack
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     name_template: >-
       {{ .ProjectName }}-
       {{- title .Os }}-
@@ -47,7 +47,7 @@ checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   sort: asc


### PR DESCRIPTION
- Bump .goreleaser.yml to schema version 2.
- Rename snapshot.name_template -> snapshot.version_template,
  archives.format -> archives.formats, and
  archives.format_overrides.format -> archives.format_overrides.formats
  per the v2.2/v2.6 deprecation notices.
- Pin goreleaser-action's version input to '~> v2' instead of 'latest'
  so the release workflow stays on the v2 major line.

Verified locally with `goreleaser check` (no deprecation warnings) and
a snapshot build.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018Td8tpdygRMVnmLj5tQof1